### PR TITLE
feat(bg, title): ページタイトルと背景を設定

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,6 @@
+html,
+body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/global.css
+++ b/src/global.css
@@ -3,4 +3,5 @@ body {
   margin: 0;
   width: 100%;
   height: 100%;
+  background-color: #f9f8f6;
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,3 +1,10 @@
+---
+export interface Props {
+  title?: string;
+}
+
+const { title } = Astro.props;
+---
 <!doctype html>
 <html lang="ja">
   <head>
@@ -5,7 +12,7 @@
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
-    <title>Astro Basics</title>
+    <title>{title}</title>
   </head>
   <body>
     <slot />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import "./global.css";
+import "../global.css";
 export interface Props {
   title?: string;
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,8 +3,14 @@ export interface Props {
   title?: string;
 }
 
-const { title } = Astro.props;
+const { title: pageTitle } = Astro.props;
+const siteTitle = "珈琲・俺";
+
+// トップページならサイトタイトルだけ、そうでなければ「ページタイトル | サイトタイトル」とする
+const fullTitle =
+  Astro.url.pathname === "/" ? siteTitle : `${pageTitle} | ${siteTitle}`;
 ---
+
 <!doctype html>
 <html lang="ja">
   <head>
@@ -12,7 +18,7 @@ const { title } = Astro.props;
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
-    <title>{title}</title>
+    <title>{fullTitle}</title>
   </head>
   <body>
     <slot />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import "./global.css";
 export interface Props {
   title?: string;
 }
@@ -24,12 +25,3 @@ const fullTitle =
     <slot />
   </body>
 </html>
-
-<style>
-  html,
-  body {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-  }
-</style>


### PR DESCRIPTION
layout.astroを修正し、以下の機能を追加。また、その修正の一環としてglobal.cssを作成。

# 追加機能
- headタグ内のtitleタグの値を動的に生成
  - 「(ページタイトル) | 珈琲・俺」と表示されるように
  - トップページは「珈琲・俺」と表示
- 背景色を#f9f8f6に指定
  - この修正と一緒に、global.cssを作成。layout.astro内のstyleタグの内容をglobal.css内に移行。
