### PR TITLE
feat(aticle): 記事のデザインの実装

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -4,4 +4,5 @@ body {
   width: 100%;
   height: 100%;
   background-color: #f9f8f6;
+  font-family: "Hiragino Kaku Gothic ProN", "Noto Sans JP";
 }

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -9,6 +9,14 @@ export async function getStaticPaths() {
 const { id } = Astro.params;
 const article = await getArticleById(id);
 const { publishedAt, updatedAt, title, content, thumbnail } = article;
+const formatDate = (dateString: string) => {
+  return new Date(dateString).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone: "Asia/Tokyo",
+  });
+};
 ---
 
 <Layout>

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -32,7 +32,7 @@ const formatDate = (dateString: string) => {
 </Layout>
 
 <style>
-  .article-container {
+  <style > .article-container {
     width: 90%;
     max-width: none;
     margin: 0 auto;
@@ -40,6 +40,23 @@ const formatDate = (dateString: string) => {
     @media (min-width: 768px) {
       max-width: 40%;
       padding: 0 2rem;
+    }
+  }
+
+  h1 {
+    color: #006367;
+    font-family: Serif;
+  }
+
+  .article-content {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: #006367;
+      font-family: Serif;
     }
   }
 </style>

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -32,7 +32,7 @@ const formatDate = (dateString: string) => {
 </Layout>
 
 <style>
-  <style > .article-container {
+  .article-container {
     width: 90%;
     max-width: none;
     margin: 0 auto;
@@ -58,5 +58,20 @@ const formatDate = (dateString: string) => {
       color: #006367;
       font-family: Serif;
     }
+    /* content内の画像にスタイルを適用 */
+    img {
+      width: 100%;
+      height: auto;
+      max-width: 100%;
+      display: block;
+      margin: 1rem 0;
+    }
+  }
+
+  /* サムネイル画像のレスポンシブ対応 */
+  img {
+    width: 100%;
+    height: auto;
+    max-width: 100%;
   }
 </style>

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -47,29 +47,6 @@ const formatDate = (dateString: string) => {
   }
   h1 {
     color: #006367;
-    font-family: "Hiragino ";
-  }
-  .article-content {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      color: #006367;
-      font-family: Serif;
-    }
-    .published-date {
-      color: #006367;
-    }
-    /* content内の画像にスタイルを適用 */
-    img {
-      width: 100%;
-      height: auto;
-      max-width: 100%;
-      display: block;
-      margin: 1rem 0;
-    }
   }
   /* サムネイル画像のレスポンシブ対応 */
   img {
@@ -98,5 +75,26 @@ const formatDate = (dateString: string) => {
     white-space: nowrap;
     flex-shrink: 0;
     margin-bottom: 0.4rem;
+  }
+  .article-content {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: #006367;
+    }
+    .published-date {
+      color: #006367;
+    }
+    /* content内の画像にスタイルを適用 */
+    img {
+      width: 100%;
+      height: auto;
+      max-width: 100%;
+      display: block;
+      margin: 1rem 0;
+    }
   }
 </style>

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -32,6 +32,8 @@ const formatDate = (dateString: string) => {
 </Layout>
 
 <style>
+  main {
+  }
   .article-container {
     width: 90%;
     max-width: none;
@@ -42,12 +44,10 @@ const formatDate = (dateString: string) => {
       padding: 0 2rem;
     }
   }
-
   h1 {
     color: #006367;
     font-family: Serif;
   }
-
   .article-content {
     h1,
     h2,
@@ -58,6 +58,9 @@ const formatDate = (dateString: string) => {
       color: #006367;
       font-family: Serif;
     }
+    .published-date {
+      color: #006367;
+    }
     /* content内の画像にスタイルを適用 */
     img {
       width: 100%;
@@ -67,11 +70,32 @@ const formatDate = (dateString: string) => {
       margin: 1rem 0;
     }
   }
-
   /* サムネイル画像のレスポンシブ対応 */
   img {
     width: 100%;
     height: auto;
     max-width: 100%;
+  }
+
+  .title-date {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .title-date h1 {
+    margin: 0;
+    margin-bottom: 0;
+  }
+
+  .title-date p {
+    margin: 0;
+    color: #64a19e;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-bottom: 0.4rem;
   }
 </style>

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -29,11 +29,4 @@ const formatDate = (dateString: string) => {
   </main>
 </Layout>
 
-<style>
-  .article-content {
-    /* TODO: Add styles for article contents */
-    h2 {
-      color: red;
-    }
-  }
-</style>
+<style></style>

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -22,8 +22,8 @@ const formatDate = (dateString: string) => {
 <Layout>
   <main>
     <h1>{title}</h1>
-    <p>publishedAt: {publishedAt}</p>
-    <p>updatedAt: {updatedAt}</p>
+    <p class="published-date">{formatDate(publishedAt)}</p>
+
     {thumbnail && <img src={thumbnail.url} alt={title} />}
     <div class="article-content" set:html={content} />
   </main>

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -43,10 +43,11 @@ const formatDate = (dateString: string) => {
       max-width: 40%;
       padding: 0 2rem;
     }
+    font-family: "Hiragino Kaku Gothic ProN", "Noto Sans JP";
   }
   h1 {
     color: #006367;
-    font-family: Serif;
+    font-family: "Hiragino ";
   }
   .article-content {
     h1,

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -43,7 +43,6 @@ const formatDate = (dateString: string) => {
       max-width: 40%;
       padding: 0 2rem;
     }
-    font-family: "Hiragino Kaku Gothic ProN", "Noto Sans JP";
   }
   h1 {
     color: #006367;

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -21,12 +21,25 @@ const formatDate = (dateString: string) => {
 
 <Layout>
   <main>
-    <h1>{title}</h1>
-    <p class="published-date">{formatDate(publishedAt)}</p>
+    <div class="article-container">
+      <h1>{title}</h1>
+      <p class="published-date">{formatDate(publishedAt)}</p>
 
-    {thumbnail && <img src={thumbnail.url} alt={title} />}
-    <div class="article-content" set:html={content} />
+      {thumbnail && <img src={thumbnail.url} alt={title} />}
+      <div class="article-content" set:html={content} />
+    </div>
   </main>
 </Layout>
 
-<style></style>
+<style>
+  .article-container {
+    width: 90%;
+    max-width: none;
+    margin: 0 auto;
+    padding: 0 1rem;
+    @media (min-width: 768px) {
+      max-width: 40%;
+      padding: 0 2rem;
+    }
+  }
+</style>


### PR DESCRIPTION
# 概要

記事詳細ページにデザインを適用し、日付の表示形式を改善しました。

# 変更点

- レイアウトの導入
  - ページ全体を .article-container でラップし、中央寄せとレスポンシブな最大幅を設定しました。

- スタイリング
  - 記事タイトルと本文中の見出し (h1~h6) に、指定のフォント (Serif) と色 (#006367) を適用しました。
  - サムネイル画像と記事コンテンツ内の画像が、コンテナ幅に応じて伸縮するようにレスポンシブ対応を行いました。
  - Flexboxを用いた、タイトルと日付を横並びに配置するためのスタイル (.title-date) を追加しました。 (注: HTML構造の変更は別PRの想定)

- 日付フォーマット
  - publishedAt の日付文字列を YYYY/MM/DD 形式にフォーマットする formatDate 関数を追加しました。
  - フォーマットした日付を表示しました。

- HTML構造の変更
  - main タグ内に .article-container を追加しました。
  - 公開日の \<p> タグに .published-date クラスを付与しました。